### PR TITLE
[android]JSShareModule.java: fix typo; [ios]adapt for ios8

### DIFF
--- a/android/src/main/java/cn/jiguang/share/reactnative/JShareModule.java
+++ b/android/src/main/java/cn/jiguang/share/reactnative/JShareModule.java
@@ -220,7 +220,7 @@ public class JShareModule extends ReactContextBaseJavaModule {
                             writableMap.putString("refreshToken", refreshToken);
                             writableMap.putString("openId", openId);
                             writableMap.putString("originData", originData);
-                            succeedCallback.invoke(map);
+                            succeedCallback.invoke(writableMap);
                         }
                         break;
                 }

--- a/docs/iOSConfig.md
+++ b/docs/iOSConfig.md
@@ -11,7 +11,12 @@
 添加 `handleOpenURL`
 
 ```objective-c
-// work in iOS(2_0, 9_0)
+// work in iOS(8.0)
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  [JSHAREService handleOpenUrl:url];
+  return YES;
+}
+// work in iOS(9_0)
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url{
   [JSHAREService handleOpenUrl:url];
   return YES;
@@ -31,7 +36,7 @@ TARGET -> Build Settings -> Header Search Paths 添加搜索路径
 $(SRCROOT)/../node_modules/jshare-react-native/ios/RCTJShareModule
 ```
 
-### 配置 Info.plist 
+### 配置 Info.plist
 
 在 info.plist 文件中添加如下键值对
 
@@ -96,7 +101,7 @@ Xcode 工程目录中的 [TARGETS] -> [Info] 中设置：
 
   目前 JSHARE 支持不存在新浪微博客户端情况下的网页分享，但是由于新浪微博的 api 尚未针对 https 做优化所以需要针对新浪的做对应的 https 设置。在 JSHARE 中是默认关闭新浪微博的网页端分享的，如需使用这个功能则需要在 JSHARELaunchConfig 类的实例中将 **isSupportWebSina** 属性设置为 YES。
 
-  以iOS10 SDK 编译的工程会默认以 SSL 安全协议进行网络传输，即 HTTPS，如果依然使用 HTTP 协议请求网络会报系统异常并中断请求。目前可用如下这种方式保持用 HTTP 进行网络连接：   
+  以iOS10 SDK 编译的工程会默认以 SSL 安全协议进行网络传输，即 HTTPS，如果依然使用 HTTP 协议请求网络会报系统异常并中断请求。目前可用如下这种方式保持用 HTTP 进行网络连接：
 
 在 info.plist 中加入安全域名白名单(右键 info.plist 用 source code 打开)
 
@@ -166,7 +171,7 @@ Xcode 工程目录中的 [TARGETS] -> [Info] 中设置：
            <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
            <false/>
        </dict>
-       <!-- 新浪微博-->  
+       <!-- 新浪微博-->
    </dict>
 </dict>
 ```

--- a/example/ios/jshare/AppDelegate.m
+++ b/example/ios/jshare/AppDelegate.m
@@ -18,8 +18,8 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-  
-  
+
+
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
@@ -44,7 +44,13 @@
                         documentsDirectory,fileName];
   return filePath;
 }
-// work in iOS(2_0, 9_0)
+
+// work in iOS(8.0)
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
+  [JSHAREService handleOpenUrl:url];
+  return YES;
+}
+// work in iOS(9_0)
 - (BOOL)application:(UIApplication *)application handleOpenURL:(NSURL *)url{
   [JSHAREService handleOpenUrl:url];
   return YES;

--- a/ios/RCTJShareModule/RCTJShareModule.m
+++ b/ios/RCTJShareModule/RCTJShareModule.m
@@ -47,7 +47,7 @@ RCT_EXPORT_MODULE();
 //
 ///**
 // 启动SDK,必要!
-// 
+//
 // @param config SDK启动参数模型，不可为nil。
 // */
 //+ (void)setupWithConfig:(JSHARELaunchConfig *)config;
@@ -70,37 +70,37 @@ RCT_EXPORT_MODULE();
 
 - (JSHAREPlatform)getPlatformFromDic:(NSDictionary *)param {
   JSHAREPlatform platform = 0;
-  
+
   if (param[@"platform"]) {
     if ([param[@"platform"] isEqualToString:@"wechat_session"]) {
       platform = JSHAREPlatformWechatSession;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"wechat_timeLine"]) {
       platform = JSHAREPlatformWechatTimeLine;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"wechat_favourite"]) {
       platform = JSHAREPlatformWechatFavourite;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"qq"]) {
       platform = JSHAREPlatformQQ;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"qzone"]) {
       platform = JSHAREPlatformQzone;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"sina_weibo"]) {
       platform = JSHAREPlatformSinaWeibo;
     }
-    
+
     if ([param[@"platform"] isEqualToString:@"sina_weibo_contact"]) {
       platform = JSHAREPlatformSinaWeiboContact;
     }
   }
-  
+
   return platform;
 
 }
@@ -110,52 +110,52 @@ RCT_EXPORT_METHOD(setup:(NSDictionary *)param){
   if (param[@"appKey"]) {
     config.appKey = param[@"appKey"];
   }
-  
+
   if (param[@"channel"]) {
     config.channel = param[@"channel"];
   }
-  
+
   if (param[@"advertisingId"]) {
     config.advertisingId = param[@"advertisingId"];
   }
-  
+
   if (param[@"isProduction"]) {
     config.isProduction = param[@"isProduction"];
   }
-  
+
   if (param[@"wechatAppId"]) {
     config.WeChatAppId = param[@"wechatAppId"];
   }
-  
+
   if (param[@"wechatAppSecret"]) {
     config.WeChatAppSecret = param[@"wechatAppSecret"];
   }
-  
+
   if (param[@"qqAppId"]) {
     config.QQAppId = param[@"qqAppId"];
   }
-  
+
   if (param[@"qqAppKey"]) {
     config.QQAppKey = param[@"qqAppKey"];
   }
-  
+
   if (param[@"sinaWeiboAppKey"]) {
     config.SinaWeiboAppKey = param[@"sinaWeiboAppKey"];
   }
-  
+
   if (param[@"sinaWeiboAppSecret"]) {
     config.SinaWeiboAppSecret = param[@"sinaWeiboAppSecret"];
   }
-  
+
   if (param[@"sinaRedirectUri"]) {
     config.SinaRedirectUri = param[@"sinaRedirectUri"];
   }
-  
+
   if (param[@"isSupportWebSina"]) {
     NSNumber *isSupportWebSina = param[@"isSupportWebSina"];
     config.isSupportWebSina = [isSupportWebSina boolValue];
   }
-  
+
   [JSHAREService setupWithConfig:config];
 }
 
@@ -165,20 +165,20 @@ RCT_EXPORT_METHOD(getSocialUserInfo:(NSDictionary *)param
                   fail:(RCTResponseSenderBlock) failCallBack) {
 
   JSHAREPlatform platform = [self getPlatformFromDic:param];
-  
+
   if (platform == 0) {
     failCallBack(@[@{@"code": @(1), @"description": @"platform 参数错误"}]);
     return;
   }
-  
+
   [JSHAREService getSoicalUserInfo:platform handler:^(JSHARESocialUserInfo *userInfo, NSError *error) {
-    NSMutableDictionary *userDic = @{}.mutableCopy;
+    NSMutableDictionary *userDic = [NSMutableDictionary new];
     if (error) {
       NSString *descript = [error description];
       failCallBack(@[@{@"code": @(1), @"description": [error description]}]);
       return;
     }
-    
+
     userDic[@"name"] = userInfo.name;
     userDic[@"iconUrl"] = userInfo.iconurl;
     if (userInfo.gender == 1) {
@@ -194,25 +194,25 @@ RCT_EXPORT_METHOD(getSocialUserInfo:(NSDictionary *)param
 RCT_EXPORT_METHOD(isPlatformAuth:(NSDictionary *)param
                   success:(RCTResponseSenderBlock) successCallBack) {
   JSHAREPlatform platform = [self getPlatformFromDic:param];
-  
+
   if (platform == 0) {
     return;
   }
-  
+
     BOOL result = [JSHAREService isPlatformAuth:platform];
     successCallBack(@[@(result)]);
 }
 
 RCT_EXPORT_METHOD(cancelAuthWithPlatform:(NSDictionary *)param
                   success:(RCTResponseSenderBlock) successCallBack) {
-  
+
   JSHAREPlatform platform = [self getPlatformFromDic:param];
-  
+
   if (platform == 0) {
     successCallBack(@[@{@"code": @(1), @"description": @"platform 参数错误"}]);
     return;
   }
-  
+
   BOOL result = [JSHAREService cancelAuthWithPlatform:platform];
   successCallBack(@[@(result)]);
 }
@@ -260,17 +260,17 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
     failCallBack(@[@{@"code": @(1), @"description": @"parame error"}]);
     return;
   }
-  
+
   JSHAREMessage *message = [JSHAREMessage message];
   JSHAREPlatform platform = [self getPlatformFromString: param[@"platform"]];
-  
+
   if (platform) {
     message.platform = platform;
   } else {
     failCallBack(@[@{@"code":@(1), @"description": @"parame error: platform error"}]);
     return;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"text"]) {
     if (param[@"text"]) {
       message.text = param[@"text"];
@@ -278,16 +278,16 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
     message.mediaType = JSHAREText;
 
   }
-  
+
   if ([param[@"type"] isEqualToString: @"image"]) {
     if (param[@"imagePath"]) {
       message.image = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
-    
+
     if (param[@"text"]) {
       message.text = param[@"text"];
     }
-    
+
     if (param[@"imageArray"]) {
       NSArray *imageArr = param[@"imageArray"];
       NSMutableArray *imageDataArr = @[].mutableCopy;
@@ -296,122 +296,122 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
         [imageDataArr addObject:data];
       }
       message.images = imageDataArr;
-      
+
     }
     message.mediaType =JSHAREImage;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"video"]) {
     if (param[@"title"]) {
       message.title = param[@"title"];
     }
-    
+
     if (param[@"url"]) {
       message.mediaDataUrl = param[@"url"];
     }
-    
+
     if (param[@"text"]) {
       message.text = param[@"text"];
     }
-    
+
     if (param[@"imagePath"]) {
       message.thumbnail = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
-    
+
     message.mediaType = JSHAREVideo;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"audio"]) {
     if (param[@"title"]) {
       message.title = param[@"title"];
     }
-    
+
     if (param[@"text"]) {
       message.text = param[@"text"];
     }
-    
+
     if (param[@"url"]) {
       message.mediaDataUrl = param[@"url"];
     }
-    
+
     if (param[@"imagePath"]) {
       message.thumbnail = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
-    
+
     if (param[@"musicUrl"]) {
       message.mediaDataUrl = param[@"musicUrl"];
     }
-    
+
     message.mediaType = JSHAREAudio;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"file"]) {
     message.mediaType = JSHAREFile;
     if (param[@"path"]) {
       message.fileData = [NSData dataWithContentsOfFile:param[@"path"]];
     }
-    
+
     if (param[@"title"]) {
       message.title = param[@"title"];
     }
-    
+
     if (param[@"fileExt"]) {
       message.fileExt = param[@"fileExt"];
     }
-    
+
   }
-  
+
   if ([param[@"type"] isEqualToString: @"emoticon"]) {
     if (param[@"imagePath"]) {
       message.emoticonData = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
-    
+
     message.mediaType = JSHAREEmoticon;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"app"]) {
     if (param[@"title"]) {
       message.title = param[@"title"];
     }
-    
+
     if (param[@"text"]) {
       message.text = param[@"text"];
     }
-    
+
     if (param[@"url"]) {
       message.url = param[@"url"];
     }
-    
+
     if (param[@"extInfo"]) {
       message.extInfo = param[@"extInfo"];
     }
-    
+
     if (param[@"path"]) {
       message.fileData = [NSData dataWithContentsOfFile:param[@"path"]];
     }
     message.mediaType = JSHAREApp;
   }
-  
+
   if ([param[@"type"] isEqualToString: @"link"]) {
-    
+
     if (param[@"title"]) {
       message.title = param[@"title"];
     }
-    
+
     if (param[@"text"]) {
       message.text = param[@"text"];
     }
-    
+
     if (param[@"url"]) {
       message.url = param[@"url"];
     }
-    
+
     if (param[@"imagePath"]) {
       message.thumbnail = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
     message.mediaType = JSHARELink;
   }
-  
+
   [JSHAREService share:message handler:^(JSHAREState state, NSError *error) {
     if (error) {
       failCallBack(@[@{@"code":@(error.code), @"description": [error description]}]);
@@ -426,31 +426,31 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
   if ([platformStr isEqualToString:@"wechat_session"]) {
     return JSHAREPlatformWechatSession;
   }
-  
+
   if ([platformStr isEqualToString:@"wechat_timeLine"]) {
     return JSHAREPlatformWechatTimeLine;
   }
-  
+
   if ([platformStr isEqualToString:@"wechat_favourite"]) {
     return JSHAREPlatformWechatFavourite;
   }
-  
+
   if ([platformStr isEqualToString:@"qq"]) {
     return JSHAREPlatformQQ;
   }
-  
+
   if ([platformStr isEqualToString:@"qzone"]) {
     return JSHAREPlatformQzone;
   }
-  
+
   if ([platformStr isEqualToString:@"sina_weibo"]) {
     return JSHAREPlatformSinaWeibo;
   }
-  
+
   if ([platformStr isEqualToString:@"sina_weibo_contact"]) {
     return JSHAREPlatformSinaWeiboContact;
   }
-  
+
   return 0;
 }
 
@@ -460,15 +460,15 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
     case JSHAREStateSuccess:
       stateString = @"success";
       break;
-      
+
     case JSHAREStateFail:
       stateString = @"fail";
       break;
-      
+
     case JSHAREStateCancel:
       stateString = @"cancel";
       break;
-      
+
     case JSHAREStateUnknown:
       stateString = @"unknown";
       break;


### PR DESCRIPTION
[android]
JSShareModule.java: Avoiding crash while using method `authorize`
[ios]
adapt for ios8. code `@{}.mutableCopy` will crash on ios8 as `BAD_ACCESS`.
Add openurl support to ios8