### PR TITLE
feat(iOS): 支持imageUrl，网页分享传入图片链接作为分享icon

### DIFF
--- a/ios/RCTJShareModule/RCTJShareModule.m
+++ b/ios/RCTJShareModule/RCTJShareModule.m
@@ -468,6 +468,13 @@ RCT_EXPORT_METHOD(share:(NSDictionary *)param
     if (param[@"imagePath"]) {
       message.thumbnail = [NSData dataWithContentsOfFile:param[@"imagePath"]];
     }
+    
+    if (param[@"imageUrl"]) {
+      NSString *imageURL = param[@"imageUrl"];
+      NSData *imageData = [NSData dataWithContentsOfURL:[NSURL URLWithString:imageURL]];
+      message.thumbnail = imageData;
+    }
+    
     message.mediaType = JSHARELink;
   }
 


### PR DESCRIPTION
原有方式需要传入 imagePath，对RN使用者不友好。且安卓和iOS的配置项不一致。

现在iOS中加入imageUrl的功能，真机实测通过。